### PR TITLE
Fixes #6 Add individual commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@ libreread.db
 uploads
 *.DS_Store
 *.js.map
-server
-quote
 dump.rdb
 lr_index.bleve

--- a/cmd/quote/main.go
+++ b/cmd/quote/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Nirmal Kumar
+Copyright 2017 Gerard Braad
 
 This file is part of LibreRead.
 
@@ -17,29 +17,12 @@ You should have received a copy of the GNU General Public License
 along with LibreRead.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package libreread
+package main
 
 import (
-	"github.com/gin-gonic/gin"
+    "github.com/LibreRead/server"
 )
 
-func StartQuote() {
-	r := gin.Default()
-
-	// Router
-	r.GET("/", GetQuote)
-
-	// Listen and serve on 0.0.0.0:3000
-	r.Run(":3000")
-}
-
-func GetQuote(c *gin.Context) {
-	c.JSON(200, gin.H{
-		"quote":       "Never doubt that a small group of thoughtful, committed, citizens can change the world. Indeed, it is the only thing that ever has.",
-		"author":      "Margaret Mead",
-		"authorURL":   "https://www.goodreads.com/author/show/61107.Margaret_Mead",
-		"image":       "https://images.gr-assets.com/authors/1198589352p2/61107.jpg",
-		"fromBook":    "",
-		"fromBookURL": "",
-	})
+func main() {
+    libreread.StartQuote()
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Nirmal Kumar
+Copyright 2017 Gerard Braad
 
 This file is part of LibreRead.
 
@@ -17,29 +17,12 @@ You should have received a copy of the GNU General Public License
 along with LibreRead.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package libreread
+package main
 
 import (
-	"github.com/gin-gonic/gin"
+    "github.com/LibreRead/server"
 )
 
-func StartQuote() {
-	r := gin.Default()
-
-	// Router
-	r.GET("/", GetQuote)
-
-	// Listen and serve on 0.0.0.0:3000
-	r.Run(":3000")
-}
-
-func GetQuote(c *gin.Context) {
-	c.JSON(200, gin.H{
-		"quote":       "Never doubt that a small group of thoughtful, committed, citizens can change the world. Indeed, it is the only thing that ever has.",
-		"author":      "Margaret Mead",
-		"authorURL":   "https://www.goodreads.com/author/show/61107.Margaret_Mead",
-		"image":       "https://images.gr-assets.com/authors/1198589352p2/61107.jpg",
-		"fromBook":    "",
-		"fromBookURL": "",
-	})
+func main() {
+    libreread.StartServer()
 }

--- a/server.go
+++ b/server.go
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with LibreRead.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package main
+package libreread
 
 import (
 	"bytes"
@@ -55,7 +55,7 @@ type Env struct {
 
 var ES_PATH = os.Getenv("ES_PATH")
 
-func main() {
+func StartServer() {
 	r := gin.Default()
 
 	// Initiate session management (cookie-based)


### PR DESCRIPTION
```
$ go get ./...
$ go install -v ./cmd/server
$ go install -v ./cmd/quote
```

you can however still use:
```
$ go build -o server ./cmd/server
```

but had to remove the entries for `quote` and `server` from `.gitignore`.
